### PR TITLE
tests: remove dead torch-not-installed check

### DIFF
--- a/tests/test_seedable_mixin.py
+++ b/tests/test_seedable_mixin.py
@@ -6,13 +6,6 @@ import numpy as np
 from mixins import SeedableMixin
 from mixins.seedable import seed_everything
 
-try:
-    pass
-
-    raise ImportError("This test requires torch not to be installed to run.")
-except (ImportError, ModuleNotFoundError):
-    pass
-
 
 class SeedableDerived(SeedableMixin):
     def __init__(self):


### PR DESCRIPTION
Fixes #19.

The block at the top of `tests/test_seedable_mixin.py` raised an `ImportError` inside a bare `try: pass` and caught it immediately — it never actually checked for torch being installed. Since the CI workflow already segregates torch-requiring tests into `tests/test_torch.py`, the check is superfluous; removing it just clarifies what the file does.

## Test plan

- [x] `uv run pytest tests/test_seedable_mixin.py` — 11 pass (unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)